### PR TITLE
[design/#27] 좋아요 누른 게시물 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Post_reg from './page/Post_registration';
 import GoodsBoard from './page/GoodsBoard';
 import Signup from './page/Signup';
 import Login from './page/Login';
+import FavoriteBoard from './page/FavoriteBoard';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
       <Route path="/productdetail" element={<ProductDetail />} />
       <Route path="/signup" element={<Signup />} />
       <Route path="/login" element={<Login />} />
+      <Route path="/mypage/favoriteboard" element={<FavoriteBoard />} />
     </Routes>
   );
 }

--- a/src/page/FavoriteBoard.tsx
+++ b/src/page/FavoriteBoard.tsx
@@ -1,0 +1,118 @@
+import styled from 'styled-components';
+import Navbar from '../components/Navbar';
+import { Button, Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
+import { KeyboardArrowDown } from '@mui/icons-material';
+
+// 컨테이너 스타일
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  item-align: center;
+  justify-content: center;
+`;
+
+const SetupBoardMenu = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 18vh;
+  padding: 0 5% 0 5%;
+`;
+
+const SetupBoardTitle = styled.h1`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2rem;
+  font-weight: 300;
+  color: #ffffff;
+  text-align: center;
+  margin: 0;
+`;
+
+const SetupBoardContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: minmax(30vh, auto);
+  gap: 3vh;
+  text-align: center;
+  align-items: center;
+  padding: 0% 5% 10vh 5%;
+  height: fit-content;
+`;
+
+const SetupBoardImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  drop-shadow: 0 0 0.5rem #000000;
+
+  &:hover {
+    transform: scale(1.05);
+    transition: transform 0.5s;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  position: absolute;
+  right: 5%;
+  align-items: center;
+`;
+
+export default function FavoriteBoard() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <Container>
+      <Navbar />
+      <SetupBoardMenu>
+        <SetupBoardTitle>좋아요 누른 게시물</SetupBoardTitle>
+        <ButtonContainer>
+          <Button
+            id="basic-button"
+            aria-controls={open ? 'basic-menu' : undefined}
+            aria-haspopup="true"
+            aria-expanded={open ? 'true' : undefined}
+            onClick={handleClick}
+            size="large"
+            style={{ color: '#d3d3d3', fontSize: '1rem' }}
+            endIcon={<KeyboardArrowDown />}
+          >
+            정렬기준
+          </Button>
+          <Menu
+            id="basic-menu"
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            MenuListProps={{
+              'aria-labelledby': 'basic-button',
+            }}
+          >
+            <MenuItem onClick={handleClose}>최신순</MenuItem>
+            <MenuItem onClick={handleClose}>인기순</MenuItem>
+            <MenuItem onClick={handleClose}>가격순</MenuItem>
+          </Menu>
+        </ButtonContainer>
+      </SetupBoardMenu>
+      <SetupBoardContainer>
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+        <SetupBoardImage src="https://i.ibb.co/4jKpMfL/2024-03-25-3-45-22.png" />
+      </SetupBoardContainer>
+    </Container>
+  );
+}

--- a/src/page/Mypage.tsx
+++ b/src/page/Mypage.tsx
@@ -12,6 +12,8 @@ import plusbox from '../assets/image/mypage/plusbox.svg';
 import sumbox from '../assets/image/mypage/sum.svg';
 import changeprofile from '../assets/image/mypage/changeprofile.svg';
 import setting from '../assets/image/mypage/settings.svg';
+import { Button } from '@mui/material';
+import { Link } from 'react-router-dom';
 
 // 스타일드 컴포넌트 생성
 const ProfileContainer = styled.div`
@@ -155,6 +157,9 @@ function Mypage() {
       <div style={{ margin: '1vw' }}>
         <div style={{ fontSize: '2vw', color: 'white' }}>
           최근 좋아요 누른 게시물
+          <Link to="/mypage/favoriteboard">
+            <Button>전체보기</Button>
+          </Link>
         </div>
         <Setupbutton>
           <PostImage src={textbox} />


### PR DESCRIPTION
## 📢 기능 설명

<img width="1901" alt="스크린샷 2024-04-01 오후 4 00 35" src="https://github.com/Team-OMD/Frontend/assets/137386209/b5fd12c1-8575-4e45-9ac5-87cd7cad2442">

마이페이지에 좋아요 누른 게시물 탭에 전체보기 버튼 추가하여 이동할 수 있도록 했습니다

<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #27 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
