### PR TITLE
[feat/#39] 로그인 및 회원가입 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.2",
     "react-router-dom": "^6.22.3",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.8",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@fontsource/roboto": "^5.0.12",
+    "@hookform/resolvers": "^3.3.4",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.15",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.2",
     "react-router-dom": "^6.22.3",
     "styled-components": "^6.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.15",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
+    "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { User } from '../types/User';
+
+export const SignUp = async (jsonData: User) => {
+  const response = await axios.post(
+    'http://localhost:8080/api/signup',
+    jsonData,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+  return response.data;
+};

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -2,14 +2,39 @@ import axios from 'axios';
 import { User } from '../types/User';
 
 export const SignUp = async (jsonData: User) => {
-  const response = await axios.post(
-    'http://localhost:8080/api/signup',
-    jsonData,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axios.post(
+      'http://localhost:8080/api/signup',
+      jsonData,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    alert('회원가입이 완료되었습니다.');
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    alert('회원가입에 실패했습니다.');
+    return error;
+  }
+};
+
+export const Login = async (jsonData: { email: string; password: string }) => {
+  try {
+    const response = await axios.post(
+      'http://localhost:8080/api/login',
+      jsonData,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    return error;
+  }
 };

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -32,7 +32,8 @@ export const Login = async (jsonData: { email: string; password: string }) => {
         },
       }
     );
-    console.log(response.data);
+    // 세션스토리지에 토큰 저장
+    sessionStorage.setItem('token', response.data.data.token);
     return response.data;
   } catch (error) {
     return error;

--- a/src/page/Login.tsx
+++ b/src/page/Login.tsx
@@ -7,7 +7,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Login } from '../api/User';
-import { useState } from 'react';
 
 const LoginContainer = styled.div`
   height: 100vh;
@@ -59,7 +58,6 @@ const StyledLink1 = styled(Link)`
 
 const LoginPage = () => {
   const navigate = useNavigate();
-  const [token, setToken] = useState<string>(''); // 토큰 상태값
   // zod를 사용하여 회원가입 폼의 유효성 검사
   const signUpFormSchema = z.object({
     email: z.string().email({ message: '이메일 형식이 아닙니다.' }), // 이메일 형식 지정
@@ -174,7 +172,6 @@ const LoginPage = () => {
           const response = await Login(form.getValues());
           if (response.status === 'success') {
             alert('로그인 성공');
-            setToken(response.data.token);
             navigate('/');
           } else if (response.status === 'fail') {
             alert('이메일 또는 비밀번호가 틀렸습니다.');

--- a/src/page/Login.tsx
+++ b/src/page/Login.tsx
@@ -1,8 +1,12 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Login } from '../api/User';
 
 const LoginContainer = styled.div`
   height: 100vh;
@@ -52,72 +56,128 @@ const StyledLink1 = styled(Link)`
   font-size: 1rem;
 `;
 
-const Login = () => {
+const LoginPage = () => {
+  const navigate = useNavigate();
+  // zod를 사용하여 회원가입 폼의 유효성 검사
+  const signUpFormSchema = z.object({
+    email: z.string().email({ message: '이메일 형식이 아닙니다.' }), // 이메일 형식 지정
+    password: z // 비밀번호 형식 지정 (문자와 숫자가 혼합된 8~20자리)
+      .string()
+      .regex(
+        /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+        '문자와 숫자가 혼합된 8~20자리의 비밀번호를 입력해주세요.'
+      ),
+  });
+
+  // 회원가입 폼의 타입 지정
+  type SignUpFormValues = z.infer<typeof signUpFormSchema>;
+
+  // 회원가입 폼의 기본값 설정
+  const defaultValues: SignUpFormValues = {
+    email: '',
+    password: '',
+  };
+
+  // useForm을 사용하여 회원가입 폼의 상태 관리
+  const form = useForm({
+    resolver: zodResolver(signUpFormSchema),
+    defaultValues,
+    mode: 'all',
+  });
+
+  const {
+    register,
+    formState: { errors },
+  } = form;
+
   return (
     <LoginContainer>
       <Title>
         <StyledLink to="/">On My Desk!</StyledLink>
       </Title>
-
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="ID"
-          variant="outlined"
+      <FormProvider {...form}>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            '& > :not(style)': { width: '24vw' },
           }}
-        />
-      </Box>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="Email"
+            variant="outlined"
+            inputMode="email"
+            margin="dense"
+            error={!!errors.email}
+            {...register('email')}
+            helperText={
+              <span style={{ color: errors.email ? '#FF0040' : '#349af8' }}>
+                {errors.email
+                  ? errors.email.message
+                  : '사용가능한 이메일입니다.'}
+              </span>
+            }
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: errors.email ? '#FF0040' : '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+          <TextField
+            id="outlined-basic"
+            label="PASSWORD"
+            variant="outlined"
+            margin="dense"
+            type="password"
+            error={!!errors.password}
+            {...register('password')}
+            helperText={
+              <span style={{ color: errors.password ? '#FF0040' : '#349af8' }}>
+                {errors.password
+                  ? errors.password.message
+                  : '사용가능한 비밀번호입니다.'}
+              </span>
+            }
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: errors.password ? '#FF0040' : '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+      </FormProvider>
+      <Button
+        variant="contained"
+        sx={{ mt: 2, width: '24.2vw' }}
+        onClick={async () => {
+          const response = await Login(form.getValues());
+          if (response.status === 'success') {
+            alert('로그인 성공');
+            navigate('/');
+          } else if (response.status === 'fail') {
+            alert('이메일 또는 비밀번호가 틀렸습니다.');
+          }
         }}
-        noValidate
-        autoComplete="off"
       >
-        <TextField
-          id="outlined-basic"
-          label="PASSWORD"
-          variant="outlined"
-          type="password"
-          sx={{
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
-          }}
-        />
-      </Box>
-      <Button variant="contained" sx={{ mt: 2, width: '24.2vw' }}>
         Login
       </Button>
       <Line />
@@ -133,4 +193,4 @@ const Login = () => {
   );
 };
 
-export default Login;
+export default LoginPage;

--- a/src/page/Login.tsx
+++ b/src/page/Login.tsx
@@ -7,6 +7,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Login } from '../api/User';
+import { useState } from 'react';
 
 const LoginContainer = styled.div`
   height: 100vh;
@@ -58,6 +59,7 @@ const StyledLink1 = styled(Link)`
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const [token, setToken] = useState<string>(''); // 토큰 상태값
   // zod를 사용하여 회원가입 폼의 유효성 검사
   const signUpFormSchema = z.object({
     email: z.string().email({ message: '이메일 형식이 아닙니다.' }), // 이메일 형식 지정
@@ -172,6 +174,7 @@ const LoginPage = () => {
           const response = await Login(form.getValues());
           if (response.status === 'success') {
             alert('로그인 성공');
+            setToken(response.data.token);
             navigate('/');
           } else if (response.status === 'fail') {
             alert('이메일 또는 비밀번호가 틀렸습니다.');

--- a/src/page/Signup.tsx
+++ b/src/page/Signup.tsx
@@ -3,8 +3,10 @@ import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import { SignUp } from '../api/User';
-import { useState } from 'react';
 import { z } from 'zod';
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
 const SignupContainer = styled.div`
   height: 100vh;
   display: flex;
@@ -21,18 +23,7 @@ const Title = styled.div`
 `;
 
 const Signup = () => {
-  const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
-  const [confirmPassword, setConfirmPassword] = useState<string>('');
-  const [nickname, setNickname] = useState<string>('');
-  const [name, setName] = useState<string>('');
-  const jsonData = {
-    email: email,
-    password: password,
-    nickname: nickname,
-    name: name,
-  };
-
+  // zod를 사용하여 회원가입 폼의 유효성 검사
   const signUpFormSchema = z
     .object({
       email: z.string().email({ message: '이메일 형식이 아닙니다.' }), // 이메일 형식 지정
@@ -51,171 +42,203 @@ const Signup = () => {
       path: ['confirmPassword'],
       message: '비밀번호가 일치하지 않습니다.',
     });
+
+  // 회원가입 폼의 타입 지정
+  type SignUpFormValues = z.infer<typeof signUpFormSchema>;
+
+  // 회원가입 폼의 기본값 설정
+  const defaultValues: SignUpFormValues = {
+    email: '',
+    password: '',
+    confirmPassword: '',
+    nickname: '',
+    name: '',
+  };
+
+  // useForm을 사용하여 회원가입 폼의 상태 관리
+  const form = useForm({
+    resolver: zodResolver(signUpFormSchema),
+    defaultValues,
+    mode: 'all',
+  });
+
+  const {
+    register,
+    formState: { errors },
+    trigger,
+  } = form;
+
   return (
     <SignupContainer>
       <Title>On My Desk!</Title>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="EMAIL"
-          variant="outlined"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+      <FormProvider {...form}>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            '& > :not(style)': { m: 1, width: '24vw' },
           }}
-        />
-      </Box>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="PASSWORD"
-          variant="outlined"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="Email"
+            variant="outlined"
+            inputMode="email"
+            error={!!errors.email}
+            {...register('email')}
+            helperText={
+              <span style={{ color: errors.email ? 'red' : '#349af8' }}>
+                {errors.email
+                  ? errors.email.message
+                  : '사용가능한 이메일입니다.'}
+              </span>
+            }
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: errors.email ? 'red' : '#349af8',
+              },
+              '&: hover fieldset': {
+                borderColor: errors.email ? 'red' : '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            '& > :not(style)': { m: 1, width: '24vw' },
           }}
-        />
-      </Box>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="CONFIRM PASSWORD"
-          variant="outlined"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="PASSWORD"
+            variant="outlined"
+            {...register('password')}
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: 'white',
+              },
+              '&:hover fieldset': {
+                borderColor: '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            '& > :not(style)': { m: 1, width: '24vw' },
           }}
-        />
-      </Box>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="USERNAME"
-          variant="outlined"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="CONFIRM PASSWORD"
+            variant="outlined"
+            {...register('confirmPassword')}
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: 'white',
+              },
+              '&:hover fieldset': {
+                borderColor: '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            '& > :not(style)': { m: 1, width: '24vw' },
           }}
-        />
-      </Box>
-      <Box
-        component="form"
-        sx={{
-          '& > :not(style)': { m: 1, width: '24vw' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <TextField
-          id="outlined-basic"
-          label="NICKNAME"
-          variant="outlined"
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="USERNAME"
+            variant="outlined"
+            {...register('name')}
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: 'white',
+              },
+              '&:hover fieldset': {
+                borderColor: '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="form"
           sx={{
-            width: '100%',
-            '& label': {
-              color: '#ffffff',
-            },
-            '& fieldset': {
-              borderColor: 'white',
-            },
-            '&:hover fieldset': {
-              borderColor: '#349af8',
-            },
-            '& input': {
-              color: 'white',
-            },
+            '& > :not(style)': { m: 1, width: '24vw' },
           }}
-        />
-      </Box>
-      <Button
-        variant="contained"
-        sx={{ mt: 2, width: '24.2vw' }}
-        onClick={() => SignUp(jsonData)}
-      >
-        SIGN UP
-      </Button>
+          noValidate
+          autoComplete="off"
+        >
+          <TextField
+            id="outlined-basic"
+            label="NICKNAME"
+            variant="outlined"
+            {...register('nickname')}
+            sx={{
+              width: '100%',
+              '& label': {
+                color: '#ffffff',
+              },
+              '& fieldset': {
+                borderColor: 'white',
+              },
+              '&:hover fieldset': {
+                borderColor: '#349af8',
+              },
+              '& input': {
+                color: 'white',
+              },
+            }}
+          />
+        </Box>
+        <Button
+          variant="contained"
+          sx={{ mt: 2, width: '24.2vw' }}
+          onClick={() => SignUp(form.getValues())}
+        >
+          SIGN UP
+        </Button>
+      </FormProvider>
     </SignupContainer>
   );
 };

--- a/src/page/Signup.tsx
+++ b/src/page/Signup.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import { SignUp } from '../api/User';
+import { useState } from 'react';
 const SignupContainer = styled.div`
   height: 100vh;
   display: flex;
@@ -17,31 +19,18 @@ const Title = styled.div`
   font-size: 6rem;
 `;
 
-const Input = styled.input`
-  font-size: 1rem;
-  padding: 1.1%;
-  margin: 1% 0;
-  border: none;
-  border-radius: 0.3rem;
-  outline: none;
-  width: 22vw;
-  height: 2vh;
-`;
-
-const LoginButton = styled.button`
-  background-color: #007bff;
-  color: #fff;
-  border: none;
-  border-radius: 0.3rem;
-  margin-top: 1%;
-  width: 24.3vw;
-  height: 6vh;
-  cursor: pointer;
-  font-family: 'Kiwi Maru';
-  font-size: 1rem;
-`;
-
 const Signup = () => {
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [nickname, setNickname] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const jsonData = {
+    email: email,
+    password: password,
+    nickname: nickname,
+    name: name,
+  };
   return (
     <SignupContainer>
       <Title>On My Desk!</Title>
@@ -55,8 +44,10 @@ const Signup = () => {
       >
         <TextField
           id="outlined-basic"
-          label="ID"
+          label="EMAIL"
           variant="outlined"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           sx={{
             width: '100%',
             '& label': {
@@ -86,6 +77,8 @@ const Signup = () => {
           id="outlined-basic"
           label="PASSWORD"
           variant="outlined"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
           sx={{
             width: '100%',
             '& label': {
@@ -115,6 +108,8 @@ const Signup = () => {
           id="outlined-basic"
           label="CONFIRM PASSWORD"
           variant="outlined"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
           sx={{
             width: '100%',
             '& label': {
@@ -144,6 +139,8 @@ const Signup = () => {
           id="outlined-basic"
           label="USERNAME"
           variant="outlined"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
           sx={{
             width: '100%',
             '& label': {
@@ -161,7 +158,42 @@ const Signup = () => {
           }}
         />
       </Box>
-      <Button variant="contained" sx={{ mt: 2, width: '24.2vw' }}>
+      <Box
+        component="form"
+        sx={{
+          '& > :not(style)': { m: 1, width: '24vw' },
+        }}
+        noValidate
+        autoComplete="off"
+      >
+        <TextField
+          id="outlined-basic"
+          label="NICKNAME"
+          variant="outlined"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          sx={{
+            width: '100%',
+            '& label': {
+              color: '#ffffff',
+            },
+            '& fieldset': {
+              borderColor: 'white',
+            },
+            '&:hover fieldset': {
+              borderColor: '#349af8',
+            },
+            '& input': {
+              color: 'white',
+            },
+          }}
+        />
+      </Box>
+      <Button
+        variant="contained"
+        sx={{ mt: 2, width: '24.2vw' }}
+        onClick={() => SignUp(jsonData)}
+      >
         SIGN UP
       </Button>
     </SignupContainer>

--- a/src/page/Signup.tsx
+++ b/src/page/Signup.tsx
@@ -4,6 +4,7 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import { SignUp } from '../api/User';
 import { useState } from 'react';
+import { z } from 'zod';
 const SignupContainer = styled.div`
   height: 100vh;
   display: flex;
@@ -31,6 +32,25 @@ const Signup = () => {
     nickname: nickname,
     name: name,
   };
+
+  const signUpFormSchema = z
+    .object({
+      email: z.string().email({ message: '이메일 형식이 아닙니다.' }), // 이메일 형식 지정
+      password: z // 비밀번호 형식 지정 (문자와 숫자가 혼합된 8~20자리)
+        .string()
+        .regex(
+          /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+          '문자와 숫자가 혼합된 8~20자리의 비밀번호를 입력해주세요.'
+        ),
+      confirmPassword: z.string(),
+      nickname: z.string(),
+      name: z.string(),
+    })
+    // 비밀번호와 비밀번호 확인이 일치하는지 확인
+    .refine((data) => data.password === data.confirmPassword, {
+      path: ['confirmPassword'],
+      message: '비밀번호가 일치하지 않습니다.',
+    });
   return (
     <SignupContainer>
       <Title>On My Desk!</Title>

--- a/src/page/Signup.tsx
+++ b/src/page/Signup.tsx
@@ -102,9 +102,6 @@ const Signup = () => {
               '& fieldset': {
                 borderColor: errors.email ? 'red' : '#349af8',
               },
-              '&: hover fieldset': {
-                borderColor: errors.email ? 'red' : '#349af8',
-              },
               '& input': {
                 color: 'white',
               },
@@ -124,16 +121,20 @@ const Signup = () => {
             label="PASSWORD"
             variant="outlined"
             {...register('password')}
+            helperText={
+              <span style={{ color: errors.password ? 'red' : '#349af8' }}>
+                {errors.password
+                  ? errors.password.message
+                  : '사용가능한 비밀번호입니다.'}
+              </span>
+            }
             sx={{
               width: '100%',
               '& label': {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: 'white',
-              },
-              '&:hover fieldset': {
-                borderColor: '#349af8',
+                borderColor: errors.password ? 'red' : '#349af8',
               },
               '& input': {
                 color: 'white',
@@ -154,16 +155,22 @@ const Signup = () => {
             label="CONFIRM PASSWORD"
             variant="outlined"
             {...register('confirmPassword')}
+            helperText={
+              <span
+                style={{ color: errors.confirmPassword ? 'red' : '#349af8' }}
+              >
+                {errors.confirmPassword
+                  ? errors.confirmPassword.message
+                  : '비밀번호가 일치합니다'}
+              </span>
+            }
             sx={{
               width: '100%',
               '& label': {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: 'white',
-              },
-              '&:hover fieldset': {
-                borderColor: '#349af8',
+                borderColor: errors.confirmPassword ? 'red' : '#349af8',
               },
               '& input': {
                 color: 'white',
@@ -184,16 +191,18 @@ const Signup = () => {
             label="USERNAME"
             variant="outlined"
             {...register('name')}
+            helperText={
+              <span style={{ color: errors.name ? 'red' : '#349af8' }}>
+                {errors.name ? errors.name.message : '사용가능한 이름입니다.'}
+              </span>
+            }
             sx={{
               width: '100%',
               '& label': {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: 'white',
-              },
-              '&:hover fieldset': {
-                borderColor: '#349af8',
+                borderColor: errors.name ? 'red' : '#349af8',
               },
               '& input': {
                 color: 'white',
@@ -214,16 +223,20 @@ const Signup = () => {
             label="NICKNAME"
             variant="outlined"
             {...register('nickname')}
+            helperText={
+              <span style={{ color: errors.nickname ? 'red' : '#349af8' }}>
+                {errors.nickname
+                  ? errors.nickname.message
+                  : '사용가능한 별명입니다.'}
+              </span>
+            }
             sx={{
               width: '100%',
               '& label': {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: 'white',
-              },
-              '&:hover fieldset': {
-                borderColor: '#349af8',
+                borderColor: errors.nickname ? 'red' : '#349af8',
               },
               '& input': {
                 color: 'white',

--- a/src/page/Signup.tsx
+++ b/src/page/Signup.tsx
@@ -6,6 +6,7 @@ import { SignUp } from '../api/User';
 import { z } from 'zod';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router-dom';
 
 const SignupContainer = styled.div`
   height: 100vh;
@@ -23,6 +24,7 @@ const Title = styled.div`
 `;
 
 const Signup = () => {
+  const navigate = useNavigate();
   // zod를 사용하여 회원가입 폼의 유효성 검사
   const signUpFormSchema = z
     .object({
@@ -65,7 +67,6 @@ const Signup = () => {
   const {
     register,
     formState: { errors },
-    trigger,
   } = form;
 
   return (
@@ -75,7 +76,10 @@ const Signup = () => {
         <Box
           component="form"
           sx={{
-            '& > :not(style)': { m: 1, width: '24vw' },
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            '& > :not(style)': { width: '24vw' },
           }}
           noValidate
           autoComplete="off"
@@ -85,10 +89,11 @@ const Signup = () => {
             label="Email"
             variant="outlined"
             inputMode="email"
+            margin="dense"
             error={!!errors.email}
             {...register('email')}
             helperText={
-              <span style={{ color: errors.email ? 'red' : '#349af8' }}>
+              <span style={{ color: errors.email ? '#FF0040' : '#349af8' }}>
                 {errors.email
                   ? errors.email.message
                   : '사용가능한 이메일입니다.'}
@@ -100,29 +105,23 @@ const Signup = () => {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: errors.email ? 'red' : '#349af8',
+                borderColor: errors.email ? '#FF0040' : '#349af8',
               },
               '& input': {
                 color: 'white',
               },
             }}
           />
-        </Box>
-        <Box
-          component="form"
-          sx={{
-            '& > :not(style)': { m: 1, width: '24vw' },
-          }}
-          noValidate
-          autoComplete="off"
-        >
           <TextField
             id="outlined-basic"
             label="PASSWORD"
             variant="outlined"
+            margin="dense"
+            type="password"
+            error={!!errors.password}
             {...register('password')}
             helperText={
-              <span style={{ color: errors.password ? 'red' : '#349af8' }}>
+              <span style={{ color: errors.password ? '#FF0040' : '#349af8' }}>
                 {errors.password
                   ? errors.password.message
                   : '사용가능한 비밀번호입니다.'}
@@ -134,30 +133,26 @@ const Signup = () => {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: errors.password ? 'red' : '#349af8',
+                borderColor: errors.password ? '#FF0040' : '#349af8',
               },
               '& input': {
                 color: 'white',
               },
             }}
           />
-        </Box>
-        <Box
-          component="form"
-          sx={{
-            '& > :not(style)': { m: 1, width: '24vw' },
-          }}
-          noValidate
-          autoComplete="off"
-        >
           <TextField
             id="outlined-basic"
             label="CONFIRM PASSWORD"
             variant="outlined"
+            margin="dense"
+            type="password"
+            error={!!errors.confirmPassword}
             {...register('confirmPassword')}
             helperText={
               <span
-                style={{ color: errors.confirmPassword ? 'red' : '#349af8' }}
+                style={{
+                  color: errors.confirmPassword ? '#FF0040' : '#349af8',
+                }}
               >
                 {errors.confirmPassword
                   ? errors.confirmPassword.message
@@ -170,29 +165,22 @@ const Signup = () => {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: errors.confirmPassword ? 'red' : '#349af8',
+                borderColor: errors.confirmPassword ? '#FF0040' : '#349af8',
               },
               '& input': {
                 color: 'white',
               },
             }}
           />
-        </Box>
-        <Box
-          component="form"
-          sx={{
-            '& > :not(style)': { m: 1, width: '24vw' },
-          }}
-          noValidate
-          autoComplete="off"
-        >
           <TextField
             id="outlined-basic"
             label="USERNAME"
             variant="outlined"
+            margin="dense"
+            error={!!errors.name}
             {...register('name')}
             helperText={
-              <span style={{ color: errors.name ? 'red' : '#349af8' }}>
+              <span style={{ color: errors.name ? '#FF0040' : '#349af8' }}>
                 {errors.name ? errors.name.message : '사용가능한 이름입니다.'}
               </span>
             }
@@ -202,29 +190,22 @@ const Signup = () => {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: errors.name ? 'red' : '#349af8',
+                borderColor: errors.name ? '#FF0040' : '#349af8',
               },
               '& input': {
                 color: 'white',
               },
             }}
           />
-        </Box>
-        <Box
-          component="form"
-          sx={{
-            '& > :not(style)': { m: 1, width: '24vw' },
-          }}
-          noValidate
-          autoComplete="off"
-        >
           <TextField
             id="outlined-basic"
             label="NICKNAME"
             variant="outlined"
+            margin="dense"
+            error={!!errors.nickname}
             {...register('nickname')}
             helperText={
-              <span style={{ color: errors.nickname ? 'red' : '#349af8' }}>
+              <span style={{ color: errors.nickname ? '#FF0040' : '#349af8' }}>
                 {errors.nickname
                   ? errors.nickname.message
                   : '사용가능한 별명입니다.'}
@@ -236,7 +217,7 @@ const Signup = () => {
                 color: '#ffffff',
               },
               '& fieldset': {
-                borderColor: errors.nickname ? 'red' : '#349af8',
+                borderColor: errors.nickname ? '#FF0040' : '#349af8',
               },
               '& input': {
                 color: 'white',
@@ -247,7 +228,10 @@ const Signup = () => {
         <Button
           variant="contained"
           sx={{ mt: 2, width: '24.2vw' }}
-          onClick={() => SignUp(form.getValues())}
+          onClick={() => {
+            SignUp(form.getValues());
+            navigate('/login');
+          }}
         >
           SIGN UP
         </Button>

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,6 @@
+export interface User {
+  email: string;
+  password: string;
+  nickname: string;
+  name: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,3 +3085,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,6 +2540,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-hook-form@^7.51.2:
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.2.tgz#79f7f72ee217c5114ff831012d1a7ec344096e7f"
+  integrity sha512-y++lwaWjtzDt/XNnyGDQy6goHskFualmDlf+jzEZvjvz6KWDf7EboL7pUvRCzPTJd0EOPpdekYaQLEvvG6m6HA==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,6 +994,11 @@ ast-types-flow@^0.0.8:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -1005,6 +1010,15 @@ axe-core@=4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
+
+axios@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.2.1:
   version "3.2.1"
@@ -1115,6 +1129,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1231,6 +1252,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -1713,12 +1739,26 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2236,6 +2276,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@9.0.3:
   version "9.0.3"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
@@ -2464,6 +2516,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,6 +367,11 @@
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.0.12.tgz#418f7305a3be7fc567dd154db20090f7ece7fc6c"
   integrity sha512-x0o17jvgoSSbS9OZnUX2+xJmVRvVCfeaYJjkS7w62iN7CuJWtMf5vJj8LqgC7ibqIkitOHVW+XssRjgrcHn62g==
 
+"@hookform/resolvers@^3.3.4":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.4.tgz#de9b668c2835eb06892290192de6e2a5c906229b"
+  integrity sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz"


### PR DESCRIPTION
## 📢 기능 설명


<img width="639" alt="스크린샷 2024-04-14 오후 12 08 52" src="https://github.com/Team-OMD/Frontend/assets/137386209/2dc5222a-33c6-4687-9e7d-322cf6475e3d">

회원가입 및 로그인 기능 구현했습니다.
로그인 했을때 토큰이 발급되고 발급된 토큰은 세션스토리지에 저장됩니다.
세션스토리지에 저장된 토큰을 불러와서 api요청할때 헤더에 포함시켜 요청하시면됩니다.
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #39 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
